### PR TITLE
Add -interface and -mail optional flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,19 @@ $ cloudflare-dyndns --help
 
 Usage of cloudflare-dyndns:
   -domains string
-      Comma separated domain list to update
+    	Comma separated domain list to update
+  -interface string
+    	Obtain external IP using the specified interface
   -key string
-      CloudFlare authorization token
+    	CloudFlare authorization token
+  -mail string
+    	Delivery notifications via this mail server (optional)
   -ttl int
-      Domain time to live value (default 120)
+    	Domain time to live value (default 120)
   -update duration
-      Time interval to run the updater (default 1m0s)
+    	Time interval to run the updater (default 1m0s)
   -user string
-      CloudFlare username to update with
+    	CloudFlare username to update with
 ```
 
 ## Running from Docker


### PR DESCRIPTION
The -interface flag allows to obtain external IP using the specified interface.
The -mail <server> allows to enable mail notifications sent via <server> on updates and on errors.